### PR TITLE
style: fix project to be equal width

### DIFF
--- a/src/containers/Projects/components/Projects.js
+++ b/src/containers/Projects/components/Projects.js
@@ -35,13 +35,13 @@ const useStyles = makeStyles((theme) => ({
   grid: {
     overflow: "visible",
     display: "grid",
-    gridTemplateColumns: "repeat(3, 1fr)",
+    gridTemplateColumns: "repeat(3, minmax(0, 1fr))",
     gap: "1rem",
     [theme.breakpoints.between("xs", "sm")]: {
-      gridTemplateColumns: "repeat(2, 1fr)",
+      gridTemplateColumns: "repeat(2, minmax(0, 1fr))",
     },
     [theme.breakpoints.down("xs")]: {
-      gridTemplateColumns: "repeat(1, 1fr)",
+      gridTemplateColumns: "repeat(1, minmax(0, 1fr))",
     },
   },
 }));


### PR DESCRIPTION
## Description
- image 크기에 따라 `Project` 컴포넌트 width 사이즈가 동일하지 않게 변하는 이슈 존재
  - `grid-template-columns` 속성을 변경함으로써 모든 컴포넌트의 witdth가 동일하게 맞춰지도록 수정하였습니다. <br />

| AS-IS | TO-BE |
| :---: | :---: |
| <img width="1000" alt="스크린샷 2022-10-05 오후 11 00 42" src="https://user-images.githubusercontent.com/69497936/194079842-2294a62b-9ef1-4b25-89e4-c6809b8e5536.png"> | <img width="1000" alt="스크린샷 2022-10-05 오후 11 01 56" src="https://user-images.githubusercontent.com/69497936/194079827-2d707e75-eb04-4894-b12d-6affc3d9b8c3.png"> |


## Reference.
- [Equal width columns in CSS Grid](https://stackoverflow.com/questions/47601564/equal-width-columns-in-css-grid)